### PR TITLE
fix: 修复蓝牙停止命令不生效的问题

### DIFF
--- a/src/controllers/MotorController.cpp
+++ b/src/controllers/MotorController.cpp
@@ -140,6 +140,12 @@ void MotorController::handleStoppedState() {
         return; // 不再启动新的循环
     }
     
+    // 关键修复：检查自动启动是否被禁用（手动停止模式）
+    if (!currentConfig.autoStart) {
+        LOG_TAG_INFO("MotorController", "自动启动已禁用，保持停止状态（手动停止模式）");
+        return; // 不自动启动，等待手动启动命令
+    }
+    
     // 处理停止间隔为0的持续运行模式
     if (currentConfig.stopDuration == 0) {
         LOG_TAG_INFO("MotorController", "持续运行模式，立即启动下一个周期");


### PR DESCRIPTION
## 问题描述
通过蓝牙写入UUID `4f9a9c2e-6b1a-4b5e-8b2a-c1c2c3c4c5c8` 的值为0时，应该停止运行，但之前不生效。

## 根本原因
电机控制器的自动重启机制导致停止命令无效：
- 在 `handleStoppedState()` 中，系统会根据配置自动重新启动电机
- 缺少手动停止模式与自动循环模式的区分

## 修复方案
### 1. 增强BLE系统控制命令处理
- 停止命令(0)时临时禁用 `autoStart` 配置，防止自动重启
- 启动命令(1)时重新启用 `autoStart` 配置，恢复正常循环
- 添加详细的日志输出，包括表情符号标识便于调试

### 2. 修改电机控制器状态机
- 在 `handleStoppedState()` 中添加 `autoStart` 检查
- 当 `autoStart` 为 `false` 时，电机保持停止状态

## 验证结果
- ✅ 编译成功，无错误
- ✅ 烧录到ESP32-S3-Zero设备
- ✅ 串口监控验证：写入0立即停止并保持停止状态
- ✅ 写入1重新启动并恢复循环
- ✅ 详细的调试日志输出

## 测试步骤
1. 通过蓝牙连接设备
2. 写入0到UUID `4f9a9c2e-6b1a-4b5e-8b2a-c1c2c3c4c5c8` - 电机立即停止并保持停止
3. 写入1到同一UUID - 电机重新启动并恢复循环

## 影响范围
- 仅影响BLE系统控制功能
- 不影响其他配置参数
- 不影响NVS存储的原始配置