### PR TITLE
fix: resolve narrowing conversion warnings in MotorModbusController

### DIFF
--- a/src/controllers/MotorModbusController.cpp
+++ b/src/controllers/MotorModbusController.cpp
@@ -90,9 +90,9 @@ bool MotorModbusController::getSoftTimes(uint16_t& startTime, uint16_t& stopTime
 bool MotorModbusController::setConfig(const MotorConfig& config) {
     uint16_t values[8] = {
         config.moduleAddress,
-        config.externalSwitch ? 1 : 0,
-        config.analogControl ? 1 : 0,
-        config.powerOnState ? 1 : 0,
+        (uint16_t)(config.externalSwitch ? 1 : 0),
+        (uint16_t)(config.analogControl ? 1 : 0),
+        (uint16_t)(config.powerOnState ? 1 : 0),
         config.minOutput,
         config.maxOutput,
         config.softStartTime,


### PR DESCRIPTION
This PR resolves the narrowing conversion warnings that occurred when compiling MotorModbusController.cpp. The warnings were caused by implicit conversions from bool to uint16_t in the setConfig method. The fix explicitly casts the boolean values to uint16_t to eliminate the compiler warnings.

Changes made:
- Explicitly cast boolean values to uint16_t in the setConfig method
- No functional changes, only type safety improvements