### PR TITLE
feat: 实现调速器配置读取功能

### DIFF
--- a/src/controllers/MotorBLEServer.cpp
+++ b/src/controllers/MotorBLEServer.cpp
@@ -302,8 +302,9 @@ void MotorBLEServer::CharacteristicCallbacks::onRead(BLECharacteristic* pCharact
         String statusJson = bleServer->generateStatusJson();
         pCharacteristic->setValue(statusJson.c_str());
     } else if (strcmp(charUUID, SPEED_CONTROLLER_CONFIG_CHAR_UUID) == 0) {
-        // 返回当前的调速器配置（空JSON对象）
-        pCharacteristic->setValue("{}");
+        // 返回当前的调速器配置
+        String configJson = bleServer->generateSpeedControllerConfigJson();
+        pCharacteristic->setValue(configJson.c_str());
     }
 }
 


### PR DESCRIPTION
## 更改说明\n- 在BLE服务器中实现调速器配置的读取功能\n- 当客户端读取SPEED_CONTROLLER_CONFIG_CHAR_UUID特征时，返回实际的配置JSON而不是空对象\n\n## 测试说明\n- 已在本地测试BLE连接和配置读取功能\n- 功能符合预期