### PR TITLE
fix: 修复电机控制器计时精度问题

### DIFF
--- a/docs/timing_accuracy_diagnosis.md
+++ b/docs/timing_accuracy_diagnosis.md
@@ -1,0 +1,149 @@
+# 计时精度问题诊断报告
+
+## 🔍 问题描述
+运行时长和间隔的计时不准确，会比实际的少一些。
+
+## 📊 问题分析结果
+
+通过系统性分析，我识别出了**5个主要问题源头**：
+
+### 1. 🔴 **电源管理影响时钟精度** (高优先级)
+**位置**: [`PowerManager::enableLowPowerMode()`](../src/common/PowerManager.cpp#L20)
+**问题**: CPU频率从240MHz降低到80MHz，影响系统时钟精度
+```cpp
+// 问题代码
+setCpuFrequencyMhz(80);  // 降频可能影响millis()精度
+```
+**影响**: 系统时钟基准发生变化，导致计时偏差
+
+### 2. 🔴 **计时逻辑精度损失** (高优先级)  
+**位置**: [`MotorController::handleStoppedState()`](../src/controllers/MotorController.cpp#L182)
+**问题**: 整数除法导致毫秒级精度丢失
+```cpp
+// 问题代码
+uint32_t elapsed = (millis() - stateStartTime) / 1000;  // 丢失毫秒精度
+```
+**影响**: 每次计算都会累积误差
+
+### 3. 🟡 **主循环延时累积误差** (中优先级)
+**位置**: [`MainController::run()`](../src/controllers/MainController.cpp#L219)
+**问题**: 固定10ms延时会累积误差
+```cpp
+// 问题代码
+delay(10);  // 固定延时影响更新频率
+```
+**影响**: 影响状态更新的及时性
+
+### 4. 🟡 **未使用硬件定时器** (中优先级)
+**位置**: [`TimerDriver`](../src/drivers/TimerDriver.cpp) 未被电机控制器使用
+**问题**: 依赖软件计时而非硬件定时器
+**影响**: 硬件定时器更精确，但当前未使用
+
+### 5. 🟢 **事件处理开销** (低优先级)
+**位置**: [`MainController::run()`](../src/controllers/MainController.cpp#L182-L192)
+**问题**: BLE和事件处理的不确定延时
+**影响**: 轻微影响主循环执行周期
+
+## 🎯 **最可能的根本原因**
+
+基于分析，**问题1（电源管理）**和**问题2（精度损失）**是最可能的根本原因：
+
+1. **CPU降频直接影响时钟源精度**
+2. **整数除法每次都丢失毫秒级精度**
+
+## 🔧 修复方案
+
+### 方案1: 高精度计时修复 (推荐)
+```cpp
+// 修改 MotorController 计时逻辑
+class MotorController {
+private:
+    uint32_t stateStartTimeMs;  // 使用毫秒精度
+    
+    void handleStoppedState() {
+        if (remainingStopTime == 0) {
+            remainingStopTime = currentConfig.stopDuration * 1000;  // 转换为毫秒
+            stateStartTimeMs = millis();
+        }
+        
+        uint32_t elapsedMs = millis() - stateStartTimeMs;
+        if (elapsedMs >= remainingStopTime) {
+            // 时间到达
+            remainingStopTime = 0;
+            setState(MotorControllerState::STARTING);
+        } else {
+            remainingStopTime = (currentConfig.stopDuration * 1000) - elapsedMs;
+        }
+    }
+};
+```
+
+### 方案2: 使用硬件定时器
+```cpp
+// 使用 TimerDriver 替代 millis() 计时
+bool MotorController::init() {
+    // 创建硬件定时器用于精确计时
+    timer.createTimer(TimerDriver::TIMER_0, 100, [this]() {
+        this->onTimerTick();
+    });
+    timer.startTimer(TimerDriver::TIMER_0);
+}
+
+void MotorController::onTimerTick() {
+    // 每100ms精确更新一次状态
+    updateTimingCounters();
+}
+```
+
+### 方案3: 优化电源管理
+```cpp
+// 修改 PowerManager，保持时钟精度
+void PowerManager::enableLowPowerMode() {
+    // 不降低CPU频率，或使用更保守的降频
+    setCpuFrequencyMhz(160);  // 而不是80MHz
+    
+    // 或者完全不降频，只优化其他功耗
+    // setCpuFrequencyMhz(240);  // 保持原频率
+}
+```
+
+## 🧪 验证方法
+
+我已经添加了调试日志来验证计时精度：
+
+```cpp
+// 调试日志会显示：
+// - 配置时间 vs 实际时间
+// - 计时误差（毫秒级）
+// - 每5秒的精度检查
+
+LOG_TAG_INFO("MotorController", "运行周期完成 - 配置: %lu s, 实际: %lu s, 误差: %ld ms", 
+             configDuration, actualDuration, timingError);
+```
+
+## 📋 实施建议
+
+### 立即修复 (高优先级)
+1. **实施方案1**: 修改计时逻辑使用毫秒精度
+2. **测试验证**: 使用添加的调试日志验证修复效果
+
+### 后续优化 (中优先级)  
+1. **实施方案2**: 考虑使用硬件定时器
+2. **实施方案3**: 优化电源管理策略
+
+### 长期改进 (低优先级)
+1. 优化主循环延时策略
+2. 减少事件处理开销
+
+## 🔍 调试步骤
+
+1. **启用调试日志**: 已添加详细的计时调试信息
+2. **运行测试**: 观察实际计时误差
+3. **应用修复**: 根据测试结果选择最佳方案
+4. **验证效果**: 确认计时精度改善
+
+## 📈 预期效果
+
+- **精度提升**: 从秒级精度提升到毫秒级精度
+- **误差减少**: 预计计时误差减少90%以上
+- **稳定性**: 消除累积误差问题

--- a/docs/timing_fix_summary.md
+++ b/docs/timing_fix_summary.md
@@ -1,0 +1,120 @@
+# 计时精度问题修复总结
+
+## 🎯 **问题描述**
+运行时长和间隔的计时不准确，会比实际的少一些。
+
+## 📊 **问题验证**
+通过调试日志确认了严重的计时问题：
+- **运行时间**: 配置5秒，实际只有3秒，误差-1996ms (-40%)
+- **停止时间**: 配置30秒，实际只有15秒，误差-14990ms (-50%)
+
+## 🔍 **根本原因分析**
+1. **整数除法精度损失**: `(millis() - stateStartTime) / 1000` 每次都丢失毫秒级精度
+2. **电源管理影响**: CPU降频到80MHz可能影响系统时钟精度
+
+## ✅ **实施的修复**
+
+### 1. 高精度计时逻辑修复
+**修复文件**: `src/controllers/MotorController.cpp`
+**修复方法**: `handleStoppedState()` 和 `handleRunningState()`
+
+**核心改进**:
+- **内部存储**: `remainingRunTime` 和 `remainingStopTime` 现在使用毫秒精度
+- **精确比较**: 直接比较毫秒值，避免整数除法精度损失
+- **详细日志**: 添加毫秒级精度的调试信息
+
+**修复前**:
+```cpp
+// 问题代码 - 精度损失
+uint32_t elapsed = (millis() - stateStartTime) / 1000;
+if (elapsed >= remainingStopTime) {
+    // 时间到达
+}
+remainingStopTime = currentConfig.stopDuration - elapsed;
+```
+
+**修复后**:
+```cpp
+// 修复代码 - 毫秒精度
+uint32_t elapsedMs = millis() - stateStartTime;
+uint32_t targetDurationMs = currentConfig.stopDuration * 1000;
+if (elapsedMs >= targetDurationMs) {
+    // 时间到达，显示精确误差
+    long timingError = (long)elapsedMs - (long)targetDurationMs;
+    LOG_TAG_INFO("MotorController", "配置: %lu ms, 实际: %lu ms, 误差: %ld ms", 
+                 targetDurationMs, elapsedMs, timingError);
+}
+remainingStopTime = targetDurationMs - elapsedMs;
+```
+
+### 2. BLE接口兼容性修复
+**修复文件**: `src/controllers/MotorController.cpp` 和 `src/controllers/MotorController.h`
+
+**问题**: 内部改为毫秒存储后，BLE接口仍需要返回秒
+**解决方案**: 在getter方法中转换单位
+
+```cpp
+// 获取剩余运行时间（返回秒，用于BLE接口）
+uint32_t MotorController::getRemainingRunTime() const {
+    return remainingRunTime / 1000;  // 转换毫秒为秒
+}
+
+// 获取剩余停止时间（返回秒，用于BLE接口）
+uint32_t MotorController::getRemainingStopTime() const {
+    return remainingStopTime / 1000;  // 转换毫秒为秒
+}
+```
+
+### 3. 配置更新逻辑修复
+**修复文件**: `src/controllers/MotorController.cpp`
+**修复方法**: `updateConfig()`
+
+**问题**: 配置更新时需要考虑内部毫秒存储
+**解决方案**: 转换配置值为毫秒进行比较
+
+```cpp
+// 修复后 - 正确处理毫秒单位
+if (currentState == MotorControllerState::RUNNING) {
+    uint32_t newRunTimeMs = currentConfig.runDuration * 1000;
+    if (remainingRunTime > newRunTimeMs) {
+        remainingRunTime = newRunTimeMs;
+    }
+}
+```
+
+## 📈 **修复效果**
+
+### 预期改进
+- **精度提升**: 从秒级精度提升到毫秒级精度
+- **误差减少**: 从40-50%的误差减少到<2%
+- **稳定性**: 消除累积误差问题
+
+### 验证方法
+- 详细的毫秒级调试日志
+- 配置时间vs实际时间对比
+- 精确的误差统计报告
+
+## 🔧 **技术细节**
+
+### 内部实现
+- **存储单位**: 内部使用毫秒 (`remainingRunTime`, `remainingStopTime`)
+- **计算精度**: 直接使用毫秒比较，无精度损失
+- **接口兼容**: 对外接口仍返回秒，保持BLE兼容性
+
+### 调试信息
+```
+[INFO] 开始运行时间倒计时: 5000 ms (5.0 秒, 开始时间: 74607 ms)
+[INFO] 运行周期完成 - 配置: 5000 ms (5.0 s), 实际: 5003 ms (5.0 s), 误差: 3 ms
+```
+
+## ✅ **验证结果**
+用户确认：**"现在时间准确了"**
+
+## 📋 **文件修改清单**
+1. `src/controllers/MotorController.cpp` - 核心计时逻辑修复
+2. `src/controllers/MotorController.h` - 接口注释更新
+3. `docs/timing_accuracy_diagnosis.md` - 详细诊断报告
+4. `docs/timing_fix_summary.md` - 修复总结（本文件）
+
+## 🎉 **修复完成**
+计时精度问题已完全解决，系统现在具有毫秒级计时精度，同时保持了BLE接口的兼容性。

--- a/src/controllers/MotorController.h
+++ b/src/controllers/MotorController.h
@@ -64,13 +64,15 @@ public:
     
     /**
      * @brief 获取剩余运行时间（秒）
-     * @return 剩余运行时间
+     * @return 剩余运行时间（秒，用于BLE接口）
+     * @note 内部使用毫秒精度计算，返回时转换为秒
      */
     uint32_t getRemainingRunTime() const;
     
     /**
      * @brief 获取剩余停止时间（秒）
-     * @return 剩余停止时间
+     * @return 剩余停止时间（秒，用于BLE接口）
+     * @note 内部使用毫秒精度计算，返回时转换为秒
      */
     uint32_t getRemainingStopTime() const;
     


### PR DESCRIPTION
### 更改原因\n修复了电机控制器中计时精度不准确的问题，该问题导致运行时间和停止时间比实际配置的时间短。\n\n### 测试说明\n通过调试日志验证了修复效果，计时精度从误差40-50%提升到误差小于2%，用户已确认'现在时间准确了'。\n\n### 技术实现\n1. 在handleStoppedState和handleRunningState方法中使用毫秒精度存储和计算\n2. 消除了整数除法导致的精度损失\n3. 保持BLE接口返回秒单位的兼容性