### PR TITLE
feat: update default log level to NONE

### DIFF
--- a/src/common/Config.h
+++ b/src/common/Config.h
@@ -31,7 +31,7 @@
 
 // 日志配置
 #define LOG_BUFFER_SIZE 512       // 日志缓冲区大小
-#define LOG_DEFAULT_LEVEL LogLevel::INFO  // 默认日志级别
+#define LOG_DEFAULT_LEVEL LogLevel::NONE  // 默认日志级别
 #define LOG_ENABLE_COLORS false   // 是否启用颜色输出（串口监视器通常不支持）
 #define LOG_SHOW_TIMESTAMP true   // 是否显示时间戳
 #define LOG_SHOW_MILLISECONDS true // 时间戳是否包含毫秒


### PR DESCRIPTION
This PR updates the default log level from INFO to NONE to disable logging by default. This change helps reduce unnecessary output in production environments.