### PR TITLE
feat: 将 Modbus RTU 配置参数移到 Config.h 中预定义

### DIFF
--- a/src/common/Config.h
+++ b/src/common/Config.h
@@ -48,6 +48,12 @@
 #define BLE_STATUS_QUERY_CHAR_UUID "5f9a9c2e-6b1a-4b5e-8b2a-c1c2c3c4c5c9"
 #define BLE_SPEED_CONTROLLER_CONFIG_CHAR_UUID "6f9a9c2e-6b1a-4b5e-8b2a-c1c2c3c4c5ca"
 
+// Modbus RTU 配置
+#define MODBUS_RX_PIN 8        // RX引脚
+#define MODBUS_TX_PIN 9        // TX引脚
+#define MODBUS_BAUD_RATE 9600  // 波特率
+#define MODBUS_SLAVE_ADDRESS 0x01  // 从机地址
+
 // 配置参数结构体
 struct MotorConfig
 {

--- a/src/drivers/ModbusRTUDriver.h
+++ b/src/drivers/ModbusRTUDriver.h
@@ -2,15 +2,16 @@
 
 #include <Arduino.h>
 #include "SerialDriver.h"
+#include "../common/Config.h"
 
 class ModbusRTUDriver {
 public:
     ModbusRTUDriver();
     ~ModbusRTUDriver();
     
-    // 初始化
-    bool begin(uint8_t rxPin = 8, uint8_t txPin = 9, uint32_t baudRate = 9600, uint8_t slaveAddress = 0x01);
     
+    // 初始化
+    bool begin(uint8_t rxPin = MODBUS_RX_PIN, uint8_t txPin = MODBUS_TX_PIN, uint32_t baudRate = MODBUS_BAUD_RATE, uint8_t slaveAddress = MODBUS_SLAVE_ADDRESS);
     // MODBUS功能码实现
     bool readHoldingRegisters(uint16_t startAddress, uint16_t quantity, uint16_t* values);
     bool writeSingleRegister(uint16_t address, uint16_t value);


### PR DESCRIPTION
本次更改将 Modbus RTU 的配置参数（rxPin、txPin、baudRate、slaveAddress）从 ModbusRTUDriver 的 begin 函数默认参数移到 Config.h 中进行预定义，便于统一管理和修改。